### PR TITLE
Fix unused result warnings.

### DIFF
--- a/parameter/ParameterMgr.cpp
+++ b/parameter/ParameterMgr.cpp
@@ -2528,6 +2528,10 @@ bool CParameterMgr::handleRemoteProcessingInterface(string& strError)
 
         // Create server
         _pRemoteProcessorServer = pfnCreateRemoteProcessorServer(getConstFrameworkConfiguration()->getServerPort(), _pCommandHandler);
+        if (_pRemoteProcessorServer == nullptr) {
+            strError = "Could not create remote processor server.";
+            return false;
+        }
 
         log_info("Starting remote processor server on port %d", getConstFrameworkConfiguration()->getServerPort());
         // Start

--- a/remote-processor/RemoteProcessorServer.cpp
+++ b/remote-processor/RemoteProcessorServer.cpp
@@ -44,8 +44,12 @@ using std::string;
 CRemoteProcessorServer::CRemoteProcessorServer(uint16_t uiPort, IRemoteCommandHandler* pCommandHandler) :
     _uiPort(uiPort), _pCommandHandler(pCommandHandler), _bIsStarted(false), _pListeningSocket(NULL), _ulThreadId(0)
 {
+}
+
+bool CRemoteProcessorServer::init()
+{
     // Create inband pipe
-    pipe(_aiInbandPipe);
+    return pipe(_aiInbandPipe) == 0;
 }
 
 CRemoteProcessorServer::~CRemoteProcessorServer()
@@ -83,13 +87,12 @@ void CRemoteProcessorServer::stop()
 {
     // Check state
     if (!_bIsStarted) {
-
         return;
     }
 
     // Cause exiting of the thread
     uint8_t ucData = 0;
-    write(_aiInbandPipe[1], &ucData, sizeof(ucData));
+    TEMP_FAILURE_RETRY(write(_aiInbandPipe[1], &ucData, sizeof(ucData)));
 
     // Join thread
     pthread_join(_ulThreadId, NULL);
@@ -139,7 +142,7 @@ void CRemoteProcessorServer::run()
 
             // Consume exit request
             uint8_t ucData;
-            read(_aiInbandPipe[0], &ucData, sizeof(ucData));
+            TEMP_FAILURE_RETRY(read(_aiInbandPipe[0], &ucData, sizeof(ucData)));
 
             // Exit
             return;

--- a/remote-processor/RemoteProcessorServer.h
+++ b/remote-processor/RemoteProcessorServer.h
@@ -42,6 +42,8 @@ public:
     CRemoteProcessorServer(uint16_t uiPort, IRemoteCommandHandler* pCommandHandler);
     virtual ~CRemoteProcessorServer();
 
+    bool init();
+
     // State
     virtual bool start();
     virtual void stop();

--- a/remote-processor/RemoteProcessorServerBuilder.cpp
+++ b/remote-processor/RemoteProcessorServerBuilder.cpp
@@ -34,7 +34,13 @@ extern "C"
 {
 IRemoteProcessorServerInterface* createRemoteProcessorServer(uint16_t uiPort, IRemoteCommandHandler* pCommandHandler)
 {
-    return new CRemoteProcessorServer(uiPort, pCommandHandler);
+    auto server = new CRemoteProcessorServer(uiPort, pCommandHandler);
+    if (!server->init()) {
+        delete server;
+        return nullptr;
+    }
+
+    return server;
 }
 }
 


### PR DESCRIPTION
Android has enabled _FORTIFY_SOURCE for our host builds now, which
enables the unused result attributes on a number of functions in the C
library. This change quiets those warnings.

The result from pipe(2) is now properly plumbed to report errors, but
read(2) and write(2) only handle EINTR now; any real errors will still
be a problem. I haven't done any more because I was unsure about how
errors should be handled in those cases.
